### PR TITLE
Add setup instruction for pytest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
 # Repo Instructions
 
+- Run `pip install -e ".[dev]"` before executing `pytest`.
 - Run tests using `pytest`.


### PR DESCRIPTION
## Summary
- update AGENTS.md to instruct running `pip install -e ".[dev]"` before tests

## Testing
- `pip install -e ".[dev]"` *(fails: Could not find a version that satisfies the requirement hatchling)*
- `pytest -q` *(fails: command not found)*