### PR TITLE
Implement event line parser

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,47 @@
+import datetime
+import pytest
+
+from tg_cal_reminder.utils.parser import (
+    EventParseError,
+    PARIS_TZ,
+    parse_event_line,
+)
+
+
+@pytest.mark.parametrize(
+    "line, expected_utc",
+    [
+        (
+            "2025-05-20 14:00 Dentist",
+            (datetime.datetime(2025, 5, 20, 12, 0, tzinfo=datetime.timezone.utc), None, "Dentist"),
+        ),
+        (
+            "2025-12-31 23:00 2026-01-01 01:00 Party",
+            (
+                datetime.datetime(2025, 12, 31, 22, 0, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2026, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
+                "Party",
+            ),
+        ),
+    ],
+)
+def test_parse_valid(line, expected_utc):
+    assert parse_event_line(line) == expected_utc
+
+
+def test_invalid_date():
+    with pytest.raises(EventParseError) as err:
+        parse_event_line("2025-13-01 10:00 Bad date")
+    assert err.value.token == "date"
+
+
+def test_invalid_time():
+    with pytest.raises(EventParseError) as err:
+        parse_event_line("2025-12-01 25:00 Bad time")
+    assert err.value.token == "time"
+
+
+def test_missing_title():
+    with pytest.raises(EventParseError) as err:
+        parse_event_line("2025-12-01 10:00")
+    assert err.value.token == "title"

--- a/tg_cal_reminder/utils/parser.py
+++ b/tg_cal_reminder/utils/parser.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+
+PARIS_TZ = ZoneInfo("Europe/Paris")
+
+DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
+TIME_RE = re.compile(r"\d{2}:\d{2}")
+
+
+class EventParseError(ValueError):
+    """Raised when an event string cannot be parsed."""
+
+    def __init__(self, token: str):
+        super().__init__(token)
+        self.token = token
+
+
+def _parse_date(token: str) -> datetime:
+    try:
+        return datetime.strptime(token, "%Y-%m-%d")
+    except ValueError as exc:  # invalid date
+        raise EventParseError("date") from exc
+
+
+def _parse_time(token: str) -> datetime:
+    try:
+        return datetime.strptime(token, "%H:%M")
+    except ValueError as exc:  # invalid time
+        raise EventParseError("time") from exc
+
+
+def parse_event_line(line: str, tzinfo: ZoneInfo = PARIS_TZ) -> tuple[datetime, datetime | None, str]:
+    """Parse ``line`` into start time, optional end time and title.
+
+    Datetimes are returned in UTC.
+    """
+    if ";" in line:
+        raise EventParseError("title")
+
+    parts = line.strip().split()
+    if len(parts) < 3:
+        raise EventParseError("title")
+
+    start_date = _parse_date(parts[0])
+    start_time_part = _parse_time(parts[1])
+    start_naive = datetime.combine(start_date.date(), start_time_part.time())
+    start = start_naive.replace(tzinfo=tzinfo).astimezone(timezone.utc)
+
+    idx = 2
+    end: datetime | None = None
+    if len(parts) >= 4 and DATE_RE.fullmatch(parts[2]) and TIME_RE.fullmatch(parts[3]):
+        end_date = _parse_date(parts[2])
+        end_time_part = _parse_time(parts[3])
+        end_naive = datetime.combine(end_date.date(), end_time_part.time())
+        end = end_naive.replace(tzinfo=tzinfo).astimezone(timezone.utc)
+        idx = 4
+
+    if len(parts) <= idx:
+        raise EventParseError("title")
+    title = " ".join(parts[idx:])
+    return start, end, title


### PR DESCRIPTION
## Summary
- add `utils.parser` with `parse_event_line` function
- implement `EventParseError` to pinpoint failing token
- test event parsing logic

## Testing
- `pytest -q`