### PR TITLE
Add bot handlers and tests

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,86 @@
+import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy import select
+
+from tg_cal_reminder.db.models import Base, User
+from tg_cal_reminder.db import crud
+from tg_cal_reminder.bot import handlers
+
+
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest_asyncio.fixture
+async def async_session():
+    engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async_session_factory = lambda: AsyncSession(engine, expire_on_commit=False)
+    async with async_session_factory() as session:
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def user(async_session: AsyncSession) -> User:
+    usr = await crud.create_user(async_session, telegram_id=1, username="tester")
+    return usr
+
+
+@pytest.mark.asyncio
+async def test_dispatch_direct_add_event(async_session: AsyncSession, user: User):
+    translator = AsyncMock()
+    now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+    text = f"/add_event {now.strftime('%Y-%m-%d %H:%M')} Test"
+
+    result = await handlers.dispatch(async_session, user, text, "en", translator)
+
+    assert translator.call_count == 0
+    assert result.startswith("Event ")
+
+    events = await crud.list_events(async_session, user.id)
+    assert len(events) == 1
+    assert events[0].title == "Test"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_free_text_uses_translator(async_session: AsyncSession, user: User):
+    translator = AsyncMock(return_value={"command": "/help", "args": ""})
+
+    result = await handlers.dispatch(async_session, user, "what can you do?", "en", translator)
+
+    translator.assert_called_once()
+    assert result.startswith("/start") or result.startswith("/lang") or "help" in result
+
+
+@pytest.mark.asyncio
+async def test_handle_list_and_close(async_session: AsyncSession, user: User):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    event1 = await crud.create_event(async_session, user.id, now, "First")
+    event2 = await crud.create_event(async_session, user.id, now + datetime.timedelta(hours=1), "Second")
+
+    list_text = await handlers.handle_list_events(handlers.CommandContext(async_session, user), "")
+    assert str(event1.id) in list_text and str(event2.id) in list_text
+
+    close_result = await handlers.handle_close_event(handlers.CommandContext(async_session, user), str(event1.id))
+    assert "Closed" in close_result
+
+    result = await async_session.execute(select(User))
+    assert result.scalar_one()
+
+    events = await crud.list_events(async_session, user.id)
+    closed_ids = [e.id for e in events if e.is_closed]
+    assert event1.id in closed_ids
+    assert event2.id not in closed_ids
+
+
+@pytest.mark.asyncio
+async def test_parse_event_line_errors():
+    with pytest.raises(handlers.HandlerError):
+        await handlers.parse_event_line("invalid event")

--- a/tg_cal_reminder/bot/handlers.py
+++ b/tg_cal_reminder/bot/handlers.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import re
+from typing import Awaitable, Callable
+
+from tg_cal_reminder.db import crud
+from tg_cal_reminder.db.models import Event, User
+
+SECRET_WORD = "open-sesame"
+
+_EVENT_RE = re.compile(
+    r"^(?P<start>\d{4}-\d{2}-\d{2} \d{2}:\d{2})(?: (?P<end>\d{4}-\d{2}-\d{2} \d{2}:\d{2}))? (?P<title>.+)$"
+)
+
+
+class HandlerError(Exception):
+    """Raised when incoming command arguments are invalid."""
+
+
+@dataclass
+class CommandContext:
+    session: Awaitable
+    user: User
+
+
+async def parse_event_line(event_line: str) -> tuple[datetime, datetime | None, str]:
+    match = _EVENT_RE.match(event_line)
+    if not match:
+        raise HandlerError("Invalid event format")
+
+    start = datetime.fromisoformat(match.group("start")).replace(tzinfo=timezone.utc)
+    end = match.group("end")
+    end_dt = None
+    if end:
+        end_dt = datetime.fromisoformat(end).replace(tzinfo=timezone.utc)
+    title = match.group("title")
+    return start, end_dt, title
+
+
+async def handle_start(ctx: CommandContext, args: str) -> str:
+    return SECRET_WORD
+
+
+async def handle_lang(ctx: CommandContext, args: str) -> str:
+    language = args.strip()
+    if not language:
+        raise HandlerError("Language code required")
+    await crud.update_user_language(ctx.session, ctx.user, language)
+    return f"Language updated to {language}"
+
+
+async def handle_add_event(ctx: CommandContext, args: str) -> str:
+    start, end, title = await parse_event_line(args)
+    event = await crud.create_event(ctx.session, ctx.user.id, start, title, end)
+    warning = ""
+    if start < datetime.now(timezone.utc):
+        warning = " (past event)"
+    return f"Event {event.id} added{warning}"
+
+
+async def handle_list_events(ctx: CommandContext, args: str) -> str:
+    events = await crud.list_events(ctx.session, ctx.user.id)
+    lines = []
+    for ev in events:
+        end = ev.end_time.isoformat() if ev.end_time else "-"
+        status = "closed" if ev.is_closed else "open"
+        lines.append(f"{ev.id} {ev.start_time.isoformat()} {end} {ev.title} [{status}]")
+    return "\n".join(lines)
+
+
+async def handle_close_event(ctx: CommandContext, args: str) -> str:
+    ids = [int(part) for part in args.split() if part.isdigit()]
+    changed = await crud.close_events(ctx.session, ctx.user.id, ids)
+    if not changed:
+        return "No events closed"
+    return "Closed: " + " ".join(str(i) for i in changed)
+
+
+async def handle_help(ctx: CommandContext, args: str) -> str:
+    return (
+        "/start, /lang <code>, /add_event <event>, /list_events [username], "
+        "/close_event <id ...>, /help"
+    )
+
+
+CommandHandler = Callable[[CommandContext, str], Awaitable[str]]
+
+_HANDLERS: dict[str, CommandHandler] = {
+    "/start": handle_start,
+    "/lang": handle_lang,
+    "/add_event": handle_add_event,
+    "/list_events": handle_list_events,
+    "/close_event": handle_close_event,
+    "/help": handle_help,
+}
+
+
+async def dispatch(
+    session: Awaitable,
+    user: User,
+    text: str,
+    language_code: str,
+    translator: Callable[[str, str], Awaitable[dict]] | None = None,
+) -> str:
+    ctx = CommandContext(session=session, user=user)
+
+    if text.startswith("/"):
+        command, _, args = text.partition(" ")
+    else:
+        if translator is None:
+            raise HandlerError("No translator provided for free text")
+        result = await translator(text, language_code)
+        if "error" in result:
+            raise HandlerError(result["error"])
+        command = result.get("command", "")
+        args = result.get("args", "")
+    handler = _HANDLERS.get(command)
+    if not handler:
+        raise HandlerError("Unknown command")
+    return await handler(ctx, args)
+


### PR DESCRIPTION
## Summary
- implement `bot.handlers` module
- add command dispatching and helpers for `/add_event`, `/list_events`, `/close_event`, `/lang`, `/help`, `/start`
- create tests covering handler behaviour

## Testing
- `pytest -q`