### PR TITLE
Add i18n messages with fallback and tests

### DIFF
--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,0 +1,25 @@
+import pytest
+
+from tg_cal_reminder.i18n.messages import MESSAGES, get_message, DEFAULT_LANG
+
+
+def test_messages_structure():
+    assert isinstance(MESSAGES, dict)
+    assert DEFAULT_LANG in MESSAGES
+    assert isinstance(MESSAGES[DEFAULT_LANG], dict)
+
+
+def test_get_message_known_language():
+    msg = get_message("secret_prompt", "fr")
+    assert msg == MESSAGES["fr"]["secret_prompt"]
+
+
+def test_get_message_language_fallback():
+    msg = get_message("secret_prompt", "de")
+    assert msg == MESSAGES[DEFAULT_LANG]["secret_prompt"]
+
+
+def test_get_message_key_fallback():
+    # 'unknown_command' key is missing in French on purpose
+    msg = get_message("unknown_command", "fr")
+    assert msg == MESSAGES[DEFAULT_LANG]["unknown_command"]

--- a/tg_cal_reminder/i18n/messages.py
+++ b/tg_cal_reminder/i18n/messages.py
@@ -1,0 +1,37 @@
+"""Simple localisation messages used across the bot."""
+
+from __future__ import annotations
+
+DEFAULT_LANG = "en"
+
+MESSAGES: dict[str, dict[str, str]] = {
+    "en": {
+        "secret_prompt": "Please reply with the secret word to continue.",
+        "language_prompt": "Send /lang <code> to choose your language.",
+        "language_set": "Language changed to {language}.",
+        "help": (
+            "/add_event <event_line> – add event\n"
+            "/list_events [username] – list events\n"
+            "/close_event <id …> – close events\n"
+            "/lang <code> – change language"
+        ),
+        "unknown_command": "Unknown command. Send /help for usage.",
+    },
+    "fr": {
+        "secret_prompt": "Veuillez répondre avec le mot secret pour continuer.",
+        "language_prompt": "Envoyez /lang <code> pour choisir votre langue.",
+        "language_set": "La langue a été définie sur {language}.",
+        "help": (
+            "/add_event <ligne> – ajouter un événement\n"
+            "/list_events [utilisateur] – lister les événements\n"
+            "/close_event <id …> – clôturer des événements\n"
+            "/lang <code> – changer de langue"
+        ),
+        # Intentionally omit 'unknown_command' to test fallback
+    },
+}
+
+
+def get_message(key: str, lang: str) -> str:
+    """Return the message for ``key`` in ``lang`` falling back to English."""
+    return MESSAGES.get(lang, MESSAGES[DEFAULT_LANG]).get(key, MESSAGES[DEFAULT_LANG].get(key, key))


### PR DESCRIPTION
## Summary
- implement `i18n/messages.py` with English and French messages
- add helper `get_message` providing English fallback
- create unit tests for message retrieval behaviour

## Testing
- `pytest -q`