### PR TITLE
Implement LLM translator and tests

### DIFF
--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,0 +1,53 @@
+import json
+import pytest
+import httpx
+
+from tg_cal_reminder.llm.translator import SYSTEM_PROMPT, OPENROUTER_URL, translate_message
+
+
+@pytest.mark.asyncio
+async def test_translate_message_success(monkeypatch):
+    """Translator returns parsed JSON from LLM on success."""
+    expected = {"command": "/help", "args": ""}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == httpx.URL(OPENROUTER_URL)
+        payload = json.loads(request.content.decode())
+        # Ensure system prompt and user message are included
+        assert payload["messages"][0]["content"] == SYSTEM_PROMPT
+        assert payload["messages"][1]["content"] == "en>>> hello"
+        data = {"choices": [{"message": {"content": json.dumps(expected)}}]}
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://openrouter.ai") as client:
+        result = await translate_message(client, "hello", "en")
+
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_translate_message_invalid_json(monkeypatch):
+    """Translator raises ValueError on invalid JSON from LLM."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        data = {"choices": [{"message": {"content": "not json"}}]}
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(ValueError):
+            await translate_message(client, "hello", "en")
+
+
+@pytest.mark.asyncio
+async def test_translate_message_http_error(monkeypatch):
+    """HTTP errors are converted to RuntimeError."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(RuntimeError):
+            await translate_message(client, "hello", "en")

--- a/tg_cal_reminder/llm/translator.py
+++ b/tg_cal_reminder/llm/translator.py
@@ -1,0 +1,53 @@
+import json
+import os
+from typing import Any, Dict
+
+import httpx
+from httpx import HTTPError
+
+SYSTEM_PROMPT = (
+    "You are a translation layer for a Telegram bot. "
+    "Translate the user message into one of the supported commands: "
+    "/start, /lang <code>, /add_event <event_line>, /list_events [username], "
+    "/close_event <id …>, /help. "
+    "Return a JSON object in English like {\"command\": \"/help\", \"args\": \"\"}. "
+    "If the text does not map to a known command, return {\"error\": \"Unrecognized\"}. "
+    "Never invent new commands and always reply in English."
+)
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+async def translate_message(
+    client: httpx.AsyncClient, text: str, language_code: str
+) -> Dict[str, Any]:
+    """Translate a free-form message into a bot command via OpenRouter."""
+    payload = {
+        "model": "openrouter/auto",
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": f"{language_code}>>> {text}"},
+        ],
+        "temperature": 0,
+    }
+    headers = {
+        "Authorization": f"Bearer {os.environ.get('OPENROUTER_API_KEY', '')}",
+        "Content-Type": "application/json",
+    }
+
+    try:
+        response = await client.post(OPENROUTER_URL, json=payload, headers=headers)
+        response.raise_for_status()
+    except HTTPError as exc:  # pragma: no cover - network path is mocked in tests
+        raise RuntimeError("LLM request failed") from exc
+
+    try:
+        data = response.json()
+        content = data["choices"][0]["message"]["content"]
+    except Exception as exc:  # pragma: no cover - invalid API response
+        raise ValueError("Invalid LLM response") from exc
+
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Invalid JSON returned by LLM") from exc


### PR DESCRIPTION
## Summary
- add LLM translator helper in `llm/translator.py`
- use OpenRouter endpoint for command translation
- test translator success path and error handling

## Testing
- `pytest -q`