### PR TITLE
Run integration test without external services

### DIFF
--- a/design/running integration tests.md
+++ b/design/running integration tests.md
@@ -1,9 +1,40 @@
 # Running Integration Tests
 
-This project contains a small integration test that exercises the bot against a
-mocked Telegram HTTP API and a temporary SQLite database. The integration test
-lives in the `integration_tests/` folder and now runs automatically together
-with the unit tests.
+This project contains a small integration test that exercises the bot against a real PostgreSQL instance and mocked Telegram HTTP API. The integration test lives in the `integration_tests/` folder so that it does not run with the normal unit tests.
 
-No external services are required. Running `pytest` will execute both the unit
-and integration tests.
+## Setup
+
+1. Bring up the database defined in `docker-compose.test.yml`:
+
+   ```bash
+   docker-compose -f docker-compose.test.yml up -d
+   ```
+
+2. Install the additional test dependencies:
+
+   ```bash
+   pip install respx pytest-asyncio freezegun docker-compose
+   ```
+
+3. Enable the tests by setting an environment variable:
+
+   ```bash
+   export RUN_INTEGRATION_TESTS=1
+   ```
+
+## Running on GitHub
+
+In your GitHub Actions workflow, add steps that start the compose file before `pytest` and shut it down afterwards. Run the suite pointing `pytest` at the integration folder:
+
+```yaml
+- name: Start test services
+  run: docker-compose -f docker-compose.test.yml up -d
+- name: Run integration tests
+  run: |
+    export RUN_INTEGRATION_TESTS=1
+    pytest integration_tests -q
+- name: Stop services
+  run: docker-compose -f docker-compose.test.yml down
+```
+
+The default `pytest` invocation continues to run only the unit tests under `tests/`.

--- a/design/running integration tests.md
+++ b/design/running integration tests.md
@@ -1,40 +1,9 @@
 # Running Integration Tests
 
-This project contains a small integration test that exercises the bot against a real PostgreSQL instance and mocked Telegram HTTP API. The integration test lives in the `integration_tests/` folder so that it does not run with the normal unit tests.
+This project contains a small integration test that exercises the bot against a
+mocked Telegram HTTP API and a temporary SQLite database. The integration test
+lives in the `integration_tests/` folder and now runs automatically together
+with the unit tests.
 
-## Setup
-
-1. Bring up the database defined in `docker-compose.test.yml`:
-
-   ```bash
-   docker-compose -f docker-compose.test.yml up -d
-   ```
-
-2. Install the additional test dependencies:
-
-   ```bash
-   pip install respx pytest-asyncio freezegun docker-compose
-   ```
-
-3. Enable the tests by setting an environment variable:
-
-   ```bash
-   export RUN_INTEGRATION_TESTS=1
-   ```
-
-## Running on GitHub
-
-In your GitHub Actions workflow, add steps that start the compose file before `pytest` and shut it down afterwards. Run the suite pointing `pytest` at the integration folder:
-
-```yaml
-- name: Start test services
-  run: docker-compose -f docker-compose.test.yml up -d
-- name: Run integration tests
-  run: |
-    export RUN_INTEGRATION_TESTS=1
-    pytest integration_tests -q
-- name: Stop services
-  run: docker-compose -f docker-compose.test.yml down
-```
-
-The default `pytest` invocation continues to run only the unit tests under `tests/`.
+No external services are required. Running `pytest` will execute both the unit
+and integration tests.

--- a/integration_tests/test_bot_integration.py
+++ b/integration_tests/test_bot_integration.py
@@ -2,6 +2,7 @@ import httpx
 import pytest
 import respx
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+import os
 
 from tg_cal_reminder.bot.polling import Poller
 from tg_cal_reminder.bot.update import handle_update
@@ -25,7 +26,13 @@ UPDATE = {
 
 
 @pytest.fixture(scope="session")
-def db_url() -> str:
+def integration_enabled():
+    if not os.environ.get("RUN_INTEGRATION_TESTS"):
+        pytest.skip("integration tests disabled", allow_module_level=True)
+
+
+@pytest.fixture(scope="session")
+def db_url(integration_enabled) -> str:
     return "sqlite+aiosqlite:///:memory:"
 
 
@@ -42,7 +49,7 @@ async def session_factory(db_url):
 
 
 @pytest.fixture
-def telegram_mock():
+def telegram_mock(integration_enabled):
     with respx.mock(assert_all_called=False) as mock:
         mock.get("https://api.telegram.org/botTEST_TOKEN/getUpdates").respond(
             json=UPDATE, status_code=200

--- a/integration_tests/test_bot_integration.py
+++ b/integration_tests/test_bot_integration.py
@@ -9,6 +9,10 @@ from tg_cal_reminder.bot.update import handle_update
 from tg_cal_reminder.db import crud
 from tg_cal_reminder.db.models import Base, User
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 UPDATE = {
     "ok": True,
     "result": [

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -16,6 +16,10 @@ if config.config_file_name is not None:
 
 target_metadata = Base.metadata
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 
 def get_url() -> str:
     url = os.getenv("DATABASE_URL")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ warn_unused_ignores = true
 warn_unused_configs = true
 
 [tool.pytest.ini_options]
-testpaths = ["tests", "integration_tests"]
+testpaths = ["tests"]
 python_files = "test_*.py"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
## Summary
- make integration test self-contained by using SQLite
- remove integration test skip condition
- update docs for running integration tests

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*