### PR TITLE
Fix ruff warnings

### DIFF
--- a/tg_cal_reminder/bot/handlers.py
+++ b/tg_cal_reminder/bot/handlers.py
@@ -4,6 +4,7 @@ import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tg_cal_reminder.db import crud

--- a/tg_cal_reminder/bot/update.py
+++ b/tg_cal_reminder/bot/update.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from typing import Any
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 import httpx
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from tg_cal_reminder.bot import handlers
 from tg_cal_reminder.db import crud


### PR DESCRIPTION
## Summary
- organize imports in handlers and bot update to satisfy ruff

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`
