### PR TITLE
Fix mypy missing deps in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,13 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v3
-      - name: Install dependencies
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install project dependencies
+        run: pip install -e .
+      - name: Install mypy
         run: pip install mypy
       - name: Run mypy
         run: mypy tg_cal_reminder


### PR DESCRIPTION
## Summary
- install project dependencies before running `mypy`
- setup Python for the typecheck job

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest`
