### PR TITLE
Fix Hatch env command in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Hatch
         run: pip install hatchling hatch
       - name: Install project dependencies
-        run: hatch env create --no-build
+        run: hatch env create
       - name: Run tests
         run: hatch run test
       - name: Run integration tests


### PR DESCRIPTION
## Summary
- drop `--no-build` from the Hatch env creation in CI

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest`