### PR TITLE
Fix polling timeout

### DIFF
--- a/tg_cal_reminder/bot/polling.py
+++ b/tg_cal_reminder/bot/polling.py
@@ -36,7 +36,11 @@ class Poller:
         params = {"timeout": self.timeout}
         if self.offset is not None:
             params["offset"] = self.offset
-        response = await self.client.get("getUpdates", params=params)
+        # Use a network timeout that exceeds the long polling timeout to avoid
+        # `httpx.ReadTimeout` errors while waiting for Telegram to respond.
+        response = await self.client.get(
+            "getUpdates", params=params, timeout=self.timeout + 5
+        )
         response.raise_for_status()
         payload = response.json()
         if not payload.get("ok", False):

--- a/tg_cal_reminder/db/sessions.py
+++ b/tg_cal_reminder/db/sessions.py
@@ -18,9 +18,9 @@ load_dotenv()
 def get_engine(database_url: str | None = None) -> AsyncEngine:
     """Return a new ``AsyncEngine`` using ``database_url`` or ``DATABASE_URL`` env."""
     url = database_url or os.getenv("DATABASE_URL")
-    url = url.replace("postgres://", "postgresql+asyncpg://", 1)
     if not url:
         raise RuntimeError("DATABASE_URL environment variable is not set")
+    url = url.replace("postgres://", "postgresql+asyncpg://", 1)
     return create_async_engine(url, echo=False)
 
 


### PR DESCRIPTION
## Summary
- avoid HTTP timeout when long polling the Telegram API
- fix mypy error in `get_engine`

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f59787044832cb5d9ff74ea59c05f