### PR TITLE
Ensure DB schema is upgraded on start

### DIFF
--- a/tg_cal_reminder/main.py
+++ b/tg_cal_reminder/main.py
@@ -3,6 +3,8 @@ import logging
 import os
 
 import httpx
+from alembic import command
+from alembic.config import Config
 from dotenv import load_dotenv
 
 from tg_cal_reminder.bot import scheduler
@@ -24,6 +26,11 @@ async def main() -> None:
 
     engine = get_engine()
     session_factory = get_sessionmaker(engine)
+
+    # Run migrations to ensure the database schema is up to date.
+    # Alembic's upgrade command uses ``asyncio.run`` internally which would
+    # block the running event loop, so run it in a separate thread instead.
+    await asyncio.to_thread(command.upgrade, Config("alembic.ini"), "head")
 
     async with (
         httpx.AsyncClient(base_url=f"https://api.telegram.org/bot{token}/") as tg_client,


### PR DESCRIPTION
## Summary
- upgrade DB schema to latest revision on startup using Alembic
- move Alembic imports to the module level

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f5c9b10f4832c93b914185a674483