### PR TITLE
Fix migration URL prefix handling

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -19,11 +19,13 @@ target_metadata = Base.metadata
 load_dotenv()
 
 
-def get_url() -> str:
-    url = os.getenv("DATABASE_URL")
+def get_url(database_url: str | None = None) -> str:
+    """Return a database URL using ``database_url`` or ``DATABASE_URL`` env."""
+
+    url = database_url or os.getenv("DATABASE_URL")
     if not url:
         raise RuntimeError("DATABASE_URL environment variable is not set")
-    return url
+    return url.replace("postgres://", "postgresql+asyncpg://", 1)
 
 
 def run_migrations_offline() -> None:

--- a/tests/test_migrations_env.py
+++ b/tests/test_migrations_env.py
@@ -1,0 +1,44 @@
+import importlib
+import sys
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+
+
+def load_env(monkeypatch):
+    dummy_context = SimpleNamespace(
+        config=SimpleNamespace(config_file_name=None),
+        run_migrations=lambda: None,
+        configure=lambda **_: None,
+        begin_transaction=nullcontext,
+        is_offline_mode=lambda: True,
+    )
+    alembic_module = SimpleNamespace(context=dummy_context)
+    monkeypatch.setitem(sys.modules, "alembic", alembic_module)
+    monkeypatch.setitem(sys.modules, "alembic.context", dummy_context)
+    if "migrations.env" in sys.modules:
+        del sys.modules["migrations.env"]
+    return importlib.import_module("migrations.env")
+
+
+def test_get_url_replaces_postgres(monkeypatch):
+    env = load_env(monkeypatch)
+    monkeypatch.setenv("DATABASE_URL", "postgres://user:pass@localhost/db")
+    assert env.get_url() == "postgresql+asyncpg://user:pass@localhost/db"
+
+
+def test_get_url_preserves_postgresql(monkeypatch):
+    env = load_env(monkeypatch)
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://user:pass@localhost/db",
+    )
+    assert env.get_url() == "postgresql+asyncpg://user:pass@localhost/db"
+
+
+def test_get_url_missing(monkeypatch):
+    env = load_env(monkeypatch)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    with pytest.raises(RuntimeError):
+        env.get_url()


### PR DESCRIPTION
## Summary
- patch Alembic env `get_url()` to mirror `get_engine()`
- add tests ensuring both postgres URL formats work

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684014d0a498832cae8d68e91238234d