### PR TITLE
Implement secret gate flow

### DIFF
--- a/migrations/versions/5b221ee93923_add_is_authorized.py
+++ b/migrations/versions/5b221ee93923_add_is_authorized.py
@@ -1,0 +1,34 @@
+"""add is_authorized column
+
+Revision ID: 5b221ee93923
+Revises: bb2580a630d8
+Create Date: 2025-05-21 00:00:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '5b221ee93923'
+down_revision: str | None = 'bb2580a630d8'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "users",
+        sa.Column(
+            "is_authorized",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('users', 'is_authorized')

--- a/tg_cal_reminder/db/crud.py
+++ b/tg_cal_reminder/db/crud.py
@@ -16,9 +16,15 @@ async def create_user(
     telegram_id: int,
     username: str | None = None,
     language: str = "en",
+    is_authorized: bool = False,
 ) -> User:
     """Create and return a new ``User`` record."""
-    user = User(telegram_id=telegram_id, username=username, language=language)
+    user = User(
+        telegram_id=telegram_id,
+        username=username,
+        language=language,
+        is_authorized=is_authorized,
+    )
     session.add(user)
     await session.commit()
     await session.refresh(user)
@@ -34,6 +40,14 @@ async def get_user_by_telegram_id(session: AsyncSession, telegram_id: int) -> Us
 async def update_user_language(session: AsyncSession, user: User, language: str) -> User:
     """Update a user's language preference."""
     user.language = language
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+async def authorize_user(session: AsyncSession, user: User) -> User:
+    """Mark ``user`` as authorized."""
+    user.is_authorized = True
     await session.commit()
     await session.refresh(user)
     return user

--- a/tg_cal_reminder/db/models.py
+++ b/tg_cal_reminder/db/models.py
@@ -19,6 +19,7 @@ class User(Base):
     telegram_id: Mapped[int] = mapped_column(BigInteger, unique=True, nullable=False)
     username: Mapped[str | None] = mapped_column(String, nullable=True)
     language: Mapped[str] = mapped_column(String(2), nullable=False, default="en")
+    is_authorized: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
     )

--- a/tg_cal_reminder/i18n/messages.py
+++ b/tg_cal_reminder/i18n/messages.py
@@ -6,7 +6,7 @@ DEFAULT_LANG = "en"
 
 MESSAGES: dict[str, dict[str, str]] = {
     "en": {
-        "secret_prompt": "Please reply with the secret word to continue.",
+        "secret_prompt": "Please provide secret",
         "language_prompt": "Send /lang <code> to choose your language.",
         "language_set": "Language changed to {language}.",
         "help": (
@@ -18,7 +18,7 @@ MESSAGES: dict[str, dict[str, str]] = {
         "unknown_command": "Unknown command. Send /help for usage.",
     },
     "fr": {
-        "secret_prompt": "Veuillez répondre avec le mot secret pour continuer.",
+        "secret_prompt": "Veuillez fournir le secret",
         "language_prompt": "Envoyez /lang <code> pour choisir votre langue.",
         "language_set": "La langue a été définie sur {language}.",
         "help": (
@@ -30,7 +30,7 @@ MESSAGES: dict[str, dict[str, str]] = {
         # Intentionally omit 'unknown_command' to test fallback
     },
     "ru": {
-        "secret_prompt": "Пожалуйста, ответьте секретным словом, чтобы продолжить.",
+        "secret_prompt": "Пожалуйста, отправьте секретное слово",
         "language_prompt": "Отправьте /lang <code> чтобы выбрать язык.",
         "language_set": "Язык изменен на {language}.",
         "help": (


### PR DESCRIPTION
## Summary
- protect bot commands behind a secret
- prompt users for secret on `/start`
- authorise user when secret matches env var
- add `is_authorized` column and migration
- update localisation text and tests

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402e68bb4c832c83a738b5a08680af