### PR TITLE
Update secret prompts for authorization

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -103,11 +103,11 @@ async def test_secret_flow(async_session: AsyncSession, monkeypatch):
 
     # /start prompts for secret
     reply = await handlers.dispatch(async_session, user, "/start", "en")
-    assert reply == "Please provide secret"
+    assert reply == "Please provide a secret"
 
     # wrong secret
     reply = await handlers.dispatch(async_session, user, "wrong", "en")
-    assert reply == "Please provide a secret"
+    assert reply == "The secret is wrong. Please provide a secret"
 
     # correct secret authorizes user
     reply = await handlers.dispatch(async_session, user, "topsecret", "en")

--- a/tg_cal_reminder/bot/handlers.py
+++ b/tg_cal_reminder/bot/handlers.py
@@ -48,7 +48,7 @@ async def parse_event_line(event_line: str) -> tuple[datetime, datetime | None, 
 
 
 async def handle_start(ctx: CommandContext, args: str) -> str:
-    return "Please provide secret"
+    return "Please provide a secret"
 
 
 async def handle_lang(ctx: CommandContext, args: str) -> str:
@@ -119,8 +119,8 @@ async def dispatch(
             await crud.authorize_user(session, user)
             return 'Please write your preferred language using command "/lang en"'
         if text.startswith("/start"):
-            return "Please provide secret"
-        return "Please provide a secret"
+            return "Please provide a secret"
+        return "The secret is wrong. Please provide a secret"
 
     if text.startswith("/"):
         command, _, args = text.partition(" ")

--- a/tg_cal_reminder/i18n/messages.py
+++ b/tg_cal_reminder/i18n/messages.py
@@ -6,7 +6,7 @@ DEFAULT_LANG = "en"
 
 MESSAGES: dict[str, dict[str, str]] = {
     "en": {
-        "secret_prompt": "Please provide secret",
+        "secret_prompt": "Please provide a secret",
         "language_prompt": "Send /lang <code> to choose your language.",
         "language_set": "Language changed to {language}.",
         "help": (


### PR DESCRIPTION
## Summary
- adjust secret prompt text when starting authorization
- display clear message if secret is wrong
- update internationalized strings and tests

## Testing
- `ruff check`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840325e18e8832c97c42980a8e8921c