### PR TITLE
Fix handle_list_events exclude closed events

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -79,6 +79,13 @@ async def test_handle_list_and_close(async_session: AsyncSession, user: User):
     )
     assert "Closed" in close_result
 
+    list_text_after_close = await handlers.handle_list_events(
+        handlers.CommandContext(async_session, user), ""
+    )
+    lines = list_text_after_close.splitlines()
+    assert not any(line.startswith(f"{event1.id} ") for line in lines)
+    assert any(line.startswith(f"{event2.id} ") for line in lines)
+
     result = await async_session.execute(select(User))
     assert result.scalar_one()
 

--- a/tg_cal_reminder/bot/handlers.py
+++ b/tg_cal_reminder/bot/handlers.py
@@ -71,7 +71,7 @@ async def handle_add_event(ctx: CommandContext, args: str) -> str:
 
 
 async def handle_list_events(ctx: CommandContext, args: str) -> str:
-    events = await crud.list_events(ctx.session, ctx.user.id)
+    events = await crud.list_events(ctx.session, ctx.user.id, include_closed=False)
     lines = []
     for ev in events:
         end = ev.end_time.isoformat() if ev.end_time else "-"


### PR DESCRIPTION
## Summary
- call `crud.list_events` with `include_closed=False`
- ensure closed events don't appear in listing
- update tests accordingly

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446bb46c70832cb6623adf31877a76