### PR TITLE
Fix translator args list handling

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -55,7 +55,7 @@ async def test_dispatch_direct_add_event(async_session: AsyncSession, user: User
 
 @pytest.mark.asyncio
 async def test_dispatch_free_text_uses_translator(async_session: AsyncSession, user: User):
-    translator = AsyncMock(return_value={"command": "/help", "args": ""})
+    translator = AsyncMock(return_value={"command": "/help", "args": []})
 
     result = await handlers.dispatch(async_session, user, "what can you do?", "en", translator)
 

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -9,7 +9,7 @@ from tg_cal_reminder.llm.translator import OPENROUTER_URL, SYSTEM_PROMPT, transl
 @pytest.mark.asyncio
 async def test_translate_message_success(monkeypatch):
     """Translator returns parsed JSON from LLM on success."""
-    expected = {"command": "/help", "args": ""}
+    expected = {"command": "/help", "args": []}
 
     async def handler(request: httpx.Request) -> httpx.Response:
         assert request.url == httpx.URL(OPENROUTER_URL)

--- a/tg_cal_reminder/bot/handlers.py
+++ b/tg_cal_reminder/bot/handlers.py
@@ -180,7 +180,8 @@ async def dispatch(
         if "error" in result:
             raise HandlerError(result["error"])
         command = result.get("command", "")
-        args = result.get("args", "")
+        raw_args = result.get("args")
+        args = " ".join(raw_args) if isinstance(raw_args, list) else raw_args or ""
     handler = _HANDLERS.get(command)
     if not handler:
         raise HandlerError("Unknown command")

--- a/tg_cal_reminder/llm/translator.py
+++ b/tg_cal_reminder/llm/translator.py
@@ -40,7 +40,8 @@ SYSTEM_PROMPT = textwrap.dedent(
         error: Literal["Unrecognized"] | None = None
     ```
     If the text does not map to a known command, return {{"error": "Unrecognized"}}.
-    The answer should not contain any other text than the JSON object. The JSON object should begin with `{{` and end with `}}`.
+    The answer should not contain any other text than the JSON object.
+    The JSON object should begin with `{{` and end with `}}`.
 
     Here is the help description of all commands:
         /start


### PR DESCRIPTION
## Summary
- support translator returning argument lists
- tweak translator instructions wording
- update translator tests

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684475c0edf4832c862fbae7c959780a