### PR TITLE
Implement date-aware event listing

### DIFF
--- a/tg_cal_reminder/llm/translator.py
+++ b/tg_cal_reminder/llm/translator.py
@@ -40,7 +40,8 @@ SYSTEM_PROMPT = textwrap.dedent(
         error: Literal["Unrecognized"] | None = None
     ```
     If the text does not map to a known command, return {{"error": "Unrecognized"}}.
-    The answer should not contain any other text than the JSON object. The JSON object should begin with `{{` and end with `}}`.
+    The answer should not contain any other text than the JSON object.
+    The JSON object should begin with `{{` and end with `}}`.
 
     Here is the help description of all commands:
         /start


### PR DESCRIPTION
## Summary
- show events grouped by human-friendly date labels
- handle naive datetimes when converting to Europe/Paris timezone
- update translator docs
- update tests for new event list format

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684475865fb8832c80ebda47cbac9bc4