### PR TITLE
Update add_event confirmation message

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -46,11 +46,15 @@ async def test_dispatch_direct_add_event(async_session: AsyncSession, user: User
     result = await handlers.dispatch(async_session, user, text, "en", translator)
 
     assert translator.call_count == 0
-    assert result.startswith("Event ")
-
     events = await crud.list_events(async_session, user.id)
     assert len(events) == 1
-    assert events[0].title == "Test"
+    ev = events[0]
+    expected_time = handlers.to_paris(now).strftime("%Y-%m-%d %H:%M")
+    assert (
+        result
+        == f"Event {ev.id} added: {expected_time} {ev.title} | id={ev.id}"
+    )
+
 
 
 @pytest.mark.asyncio

--- a/tg_cal_reminder/bot/handlers.py
+++ b/tg_cal_reminder/bot/handlers.py
@@ -68,7 +68,8 @@ async def handle_add_event(ctx: CommandContext, args: str) -> str:
     warning = ""
     if start < datetime.now(UTC):
         warning = " (past event)"
-    return f"Event {event.id} added{warning}"
+    time_str = to_paris(start).strftime("%Y-%m-%d %H:%M")
+    return f"Event {event.id} added{warning}: {time_str} {title} | id={event.id}"
 
 
 def _parse_range(args: str) -> tuple[datetime | None, datetime | None]:


### PR DESCRIPTION
## Summary
- improve message returned by `/add_event`
- adjust handler test to check exact message format

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68455c319f58832c8fca24c664afb5c6