### PR TITLE
Return no events message

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -95,6 +95,12 @@ async def test_handle_list_and_close(async_session: AsyncSession, user: User):
 
 
 @pytest.mark.asyncio
+async def test_handle_list_events_no_events(async_session: AsyncSession, user: User) -> None:
+    text = await handlers.handle_list_events(handlers.CommandContext(async_session, user), "")
+    assert text == "No events found"
+
+
+@pytest.mark.asyncio
 async def test_handle_list_all_events(async_session: AsyncSession, user: User):
     now = datetime.datetime.now(datetime.UTC)
     event1 = await crud.create_event(async_session, user.id, now, "A")

--- a/tg_cal_reminder/bot/handlers.py
+++ b/tg_cal_reminder/bot/handlers.py
@@ -120,6 +120,9 @@ def _date_label(dt: datetime, now: datetime) -> str:
 
 async def handle_list_events(ctx: CommandContext, args: str) -> str:
     events = await crud.list_events(ctx.session, ctx.user.id, include_closed=False)
+    if not events:
+        return "No events found"
+
     now = datetime.now(UTC)
     lines: list[str] = []
     current_label = None


### PR DESCRIPTION
## Summary
- respond with "No events found" if /list_events returns nothing
- test listing events when none exist

## Testing
- `pytest -q`
- `mypy .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68455c773158832caf71304318b1ed7e