### PR TITLE
Switch to UTC

### DIFF
--- a/design/file_structure.md
+++ b/design/file_structure.md
@@ -28,7 +28,7 @@ calendar_bot/
 │   ├── utils/                  # Utility modules
 │   │   ├── __init__.py
 │   │   ├── parser.py           # Parses event strings (YYYY-MM-DD HH:MM ...) and validates dates
-│   │   └── timezones.py        # Europe/Paris timezone helpers and date calculations
+│   │   └── timezones.py        # UTC timezone helpers and date calculations
 │   └── main.py                 # Entrypoint: loads config, initializes DB, starts polling & scheduler
 └── tests/                      # Test suite
     ├── unit/                  # Unit tests for individual modules

--- a/design/prompt_code_one_file.md
+++ b/design/prompt_code_one_file.md
@@ -50,7 +50,7 @@ calendar_bot/
 │   ├── utils/                  # Utility modules
 │   │   ├── __init__.py
 │   │   ├── parser.py           # Parses event strings (YYYY-MM-DD HH:MM ...) and validates dates
-│   │   └── timezones.py        # Europe/Paris timezone helpers and date calculations
+│   │   └── timezones.py        # UTC timezone helpers and date calculations
 │   └── main.py                 # Entrypoint: loads config, initializes DB, starts polling & scheduler
 └── tests/                      # Test suite
     ├── unit/                  # Unit tests for individual modules
@@ -108,7 +108,7 @@ The bot:
 * talks to Telegram **strictly via long-polling using httpx** (no web-hooks)
 * persists data in **PostgreSQL** (async SQLAlchemy + asyncpg)
 * off-loads free-form user input to **OpenRouter LLM** which returns one of the **fixed commands**
-* runs on Europe/Paris time for scheduling digests.
+* runs on UTC time for scheduling digests.
 
 ---
 
@@ -119,7 +119,7 @@ The bot:
 | **FR-1**  | **Secret access gate**: after `/start`, the bot sends a one-time secret word. Messages are ignored until the sender replies with that exact word.                                                                                                                                            |
 | **FR-2**  | **Language onboarding**: as soon as the secret is accepted, ask for user’s preferred language (`/lang <code>` behind the scenes) and store it. Replies must thereafter be localised via `i18n/messages.py`.                                                                                  |
 | **FR-3**  | **Rigid command set**: only the commands in § 3 are accepted. All free-text is routed through the LLM translator which must emit one of those commands or an error.                                                                                                                          |
-| **FR-4**  | **/add\_event**: accept exactly `YYYY-MM-DD HH:MM [YYYY-MM-DD HH:MM] Title` (no semicolons).<br/>• If end-time is omitted the event is open-ended.<br/>• If start < now(), save anyway but warn the user.<br/>• Both datetimes are stored in UTC; display is converted to the user’s locale. |
+| **FR-4**  | **/add\_event**: accept exactly `YYYY-MM-DD HH:MM [YYYY-MM-DD HH:MM] Title` (no semicolons).<br/>• If end-time is omitted the event is open-ended.<br/>• If start < now(), save anyway but warn the user.<br/>• Both datetimes are stored in UTC and displayed in UTC. |
 | **FR-5**  | **/list\_events \[username]**: list events for the target (default = caller) in chronological order: (1) open events, (2) closed events, each with ID, start, end (if any) and title.                                                                                                        |
 | **FR-6**  | **/close\_event \<id …>**: mark one or many events as closed; ignore unknown IDs; report which ones changed.                                                                                                                                                                                 |
 | **FR-7**  | **/lang <code>** at any time updates the language and persists it.                                                                                                                                                                                                                           |
@@ -207,7 +207,7 @@ The bot:
 
 ## 6. Scheduling logic
 
-*All times Europe/Paris.*
+*All times UTC.*
 
 | Job            | Cron‐like schedule | Query filter                                                                                   | Recipients         |
 | -------------- | ------------------ | ---------------------------------------------------------------------------------------------- | ------------------ |

--- a/design/specification.md
+++ b/design/specification.md
@@ -13,7 +13,7 @@ The bot:
 * talks to Telegram **strictly via long-polling using httpx** (no web-hooks)
 * persists data in **PostgreSQL** (async SQLAlchemy + asyncpg)
 * off-loads free-form user input to **OpenRouter LLM** which returns one of the **fixed commands**
-* runs on Europe/Paris time for scheduling digests.
+* runs on UTC time for scheduling digests.
 
 ---
 
@@ -24,7 +24,7 @@ The bot:
 | **FR-1**  | **Secret access gate**: after `/start`, the bot sends a one-time secret word. Messages are ignored until the sender replies with that exact word.                                                                                                                                            |
 | **FR-2**  | **Language onboarding**: as soon as the secret is accepted, ask for user’s preferred language (`/lang <code>` behind the scenes) and store it. Replies must thereafter be localised via `i18n/messages.py`.                                                                                  |
 | **FR-3**  | **Rigid command set**: only the commands in § 3 are accepted. All free-text is routed through the LLM translator which must emit one of those commands or an error.                                                                                                                          |
-| **FR-4**  | **/add\_event**: accept exactly `YYYY-MM-DD HH:MM [YYYY-MM-DD HH:MM] Title` (no semicolons).<br/>• If end-time is omitted the event is open-ended.<br/>• If start < now(), save anyway but warn the user.<br/>• Both datetimes are stored in UTC; display is converted to the user’s locale. |
+| **FR-4**  | **/add\_event**: accept exactly `YYYY-MM-DD HH:MM [YYYY-MM-DD HH:MM] Title` (no semicolons).<br/>• If end-time is omitted the event is open-ended.<br/>• If start < now(), save anyway but warn the user.<br/>• Both datetimes are stored in UTC and displayed in UTC. |
 | **FR-5**  | **/list\_events \[username]**: list events for the target (default = caller) in chronological order: (1) open events, (2) closed events, each with ID, start, end (if any) and title.                                                                                                        |
 | **FR-6**  | **/close\_event \<id …>**: mark one or many events as closed; ignore unknown IDs; report which ones changed.                                                                                                                                                                                 |
 | **FR-7**  | **/lang <code>** at any time updates the language and persists it.                                                                                                                                                                                                                           |
@@ -112,7 +112,7 @@ The bot:
 
 ## 6. Scheduling logic
 
-*All times Europe/Paris.*
+*All times UTC.*
 
 | Job            | Cron‐like schedule | Query filter                                                                                   | Recipients         |
 | -------------- | ------------------ | ---------------------------------------------------------------------------------------------- | ------------------ |

--- a/design/suggested_task.md
+++ b/design/suggested_task.md
@@ -1,0 +1,3 @@
+# Suggested Task
+
+Implement an optional command `/export_ics` that returns the user's events as an iCalendar (.ics) file.

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -49,7 +49,7 @@ async def test_dispatch_direct_add_event(async_session: AsyncSession, user: User
     events = await crud.list_events(async_session, user.id)
     assert len(events) == 1
     ev = events[0]
-    expected_time = handlers.to_paris(now).strftime("%Y-%m-%d %H:%M")
+    expected_time = now.astimezone(datetime.UTC).strftime("%Y-%m-%d %H:%M")
     assert (
         result
         == f"Event {ev.id} added: {expected_time} {ev.title} | id={ev.id}"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,13 +13,13 @@ from tg_cal_reminder.utils.parser import (
     [
         (
             "2025-05-20 14:00 Dentist",
-            (datetime.datetime(2025, 5, 20, 12, 0, tzinfo=datetime.UTC), None, "Dentist"),
+            (datetime.datetime(2025, 5, 20, 14, 0, tzinfo=datetime.UTC), None, "Dentist"),
         ),
         (
             "2025-12-31 23:00 2026-01-01 01:00 Party",
             (
-                datetime.datetime(2025, 12, 31, 22, 0, tzinfo=datetime.UTC),
-                datetime.datetime(2026, 1, 1, 0, 0, tzinfo=datetime.UTC),
+                datetime.datetime(2025, 12, 31, 23, 0, tzinfo=datetime.UTC),
+                datetime.datetime(2026, 1, 1, 1, 0, tzinfo=datetime.UTC),
                 "Party",
             ),
         ),

--- a/tests/test_timezones.py
+++ b/tests/test_timezones.py
@@ -3,26 +3,23 @@ import datetime
 import pytest
 
 from tg_cal_reminder.utils.timezones import (
-    PARIS,
     UTC,
     day_bounds,
-    to_paris,
     to_utc,
     week_bounds,
 )
 
 
 def test_constants():
-    assert PARIS.key == "Europe/Paris"
     assert UTC is datetime.UTC
 
 
-def test_to_paris_and_to_utc_roundtrip():
-    dt_utc = datetime.datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
-    dt_paris = to_paris(dt_utc)
-    assert dt_paris.tzinfo == PARIS
-    assert dt_paris.hour == 13  # UTC+1 in January
-    assert to_utc(dt_paris) == dt_utc
+def test_to_utc_conversion():
+    tz = datetime.timezone(datetime.timedelta(hours=1))
+    dt_local = datetime.datetime(2024, 1, 1, 13, 0, tzinfo=tz)
+    converted = to_utc(dt_local)
+    assert converted.hour == 12
+    assert converted.tzinfo is datetime.UTC
 
 
 def test_to_utc_rejects_naive():
@@ -33,12 +30,12 @@ def test_to_utc_rejects_naive():
 def test_day_bounds():
     dt = datetime.datetime(2024, 1, 5, 15, 30, tzinfo=UTC)
     start, end = day_bounds(dt)
-    assert start == datetime.datetime(2024, 1, 5, 0, 0, tzinfo=PARIS)
-    assert end == datetime.datetime(2024, 1, 5, 23, 59, tzinfo=PARIS)
+    assert start == datetime.datetime(2024, 1, 5, 0, 0, tzinfo=UTC)
+    assert end == datetime.datetime(2024, 1, 5, 23, 59, tzinfo=UTC)
 
 
 def test_week_bounds():
-    dt = datetime.datetime(2024, 1, 5, 12, 0, tzinfo=PARIS)  # Friday
+    dt = datetime.datetime(2024, 1, 5, 12, 0, tzinfo=UTC)  # Friday
     start, end = week_bounds(dt)
-    assert start == datetime.datetime(2024, 1, 1, 0, 0, tzinfo=PARIS)
-    assert end == datetime.datetime(2024, 1, 7, 23, 59, tzinfo=PARIS)
+    assert start == datetime.datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+    assert end == datetime.datetime(2024, 1, 7, 23, 59, tzinfo=UTC)

--- a/tg_cal_reminder/bot/handlers.py
+++ b/tg_cal_reminder/bot/handlers.py
@@ -11,7 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tg_cal_reminder.db import crud
 from tg_cal_reminder.db.models import User
-from tg_cal_reminder.utils.timezones import to_paris
 
 
 def get_secret() -> str:
@@ -68,7 +67,7 @@ async def handle_add_event(ctx: CommandContext, args: str) -> str:
     warning = ""
     if start < datetime.now(UTC):
         warning = " (past event)"
-    time_str = to_paris(start).strftime("%Y-%m-%d %H:%M")
+    time_str = start.astimezone(UTC).strftime("%Y-%m-%d %H:%M")
     return f"Event {event.id} added{warning}: {time_str} {title} | id={event.id}"
 
 
@@ -107,8 +106,8 @@ def _date_label(dt: datetime, now: datetime) -> str:
         dt = dt.replace(tzinfo=UTC)
     if now.tzinfo is None:
         now = now.replace(tzinfo=UTC)
-    local = to_paris(dt)
-    today = to_paris(now).date()
+    local = dt.astimezone(UTC)
+    today = now.astimezone(UTC).date()
     diff = (local.date() - today).days
     if diff == 0:
         return "Today"
@@ -135,7 +134,7 @@ async def handle_list_events(ctx: CommandContext, args: str) -> str:
         dt = ev.start_time
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=UTC)
-        time_str = to_paris(dt).strftime("%H:%M")
+        time_str = dt.astimezone(UTC).strftime("%H:%M")
         lines.append(f"{time_str} {ev.title} | id={ev.id}")
     return "\n".join(lines)
 

--- a/tg_cal_reminder/bot/scheduler.py
+++ b/tg_cal_reminder/bot/scheduler.py
@@ -25,7 +25,7 @@ async def weekly_digest() -> None:
 
 
 def create_scheduler() -> AsyncIOScheduler:
-    """Return an ``AsyncIOScheduler`` pre-configured with digest jobs."""
+    """Return an ``AsyncIOScheduler`` pre-configured with digest jobs in UTC."""
     scheduler = AsyncIOScheduler(timezone=UTC)
     scheduler.add_job(
         morning_digest, CronTrigger(hour=6, minute=0, timezone=UTC), id="morning_digest"

--- a/tg_cal_reminder/llm/translator.py
+++ b/tg_cal_reminder/llm/translator.py
@@ -1,23 +1,22 @@
 import json
 import os
 import textwrap
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, cast
 
 import httpx
-import pytz  # type: ignore[import-untyped]
 from httpx import HTTPError
 
 
-def get_current_time_plus3() -> str:
-    tz = pytz.timezone("Etc/GMT-3")  # GMT-3 is the same as +3:00
-    return datetime.now(tz).strftime("%Y-%m-%d %H:%M:%S %Z")
+def get_current_time_utc() -> str:
+    """Return the current UTC time formatted for the system prompt."""
+    return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S %Z")
 
 
 SYSTEM_PROMPT = textwrap.dedent(
     f"""
     You are a translation layer for a Telegram bot.
-    Current time: {get_current_time_plus3()}.
+    Current time: {get_current_time_utc()}.
     Translate the user message into one of the supported commands:
     /start, /lang <code>, /add_event <event_line>, /list_events [username],
     /list_all_events [from to], /close_event <id …>, /help.

--- a/tg_cal_reminder/utils/parser.py
+++ b/tg_cal_reminder/utils/parser.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
+import datetime as dt
 import re
-from datetime import UTC, datetime
-from zoneinfo import ZoneInfo
-
-PARIS_TZ = ZoneInfo("Europe/Paris")
+from datetime import UTC
 
 DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 TIME_RE = re.compile(r"\d{2}:\d{2}")
@@ -18,23 +16,23 @@ class EventParseError(ValueError):
         self.token = token
 
 
-def _parse_date(token: str) -> datetime:
+def _parse_date(token: str) -> dt.datetime:
     try:
-        return datetime.strptime(token, "%Y-%m-%d")
+        return dt.datetime.strptime(token, "%Y-%m-%d")
     except ValueError as exc:  # invalid date
         raise EventParseError("date") from exc
 
 
-def _parse_time(token: str) -> datetime:
+def _parse_time(token: str) -> dt.datetime:
     try:
-        return datetime.strptime(token, "%H:%M")
+        return dt.datetime.strptime(token, "%H:%M")
     except ValueError as exc:  # invalid time
         raise EventParseError("time") from exc
 
 
 def parse_event_line(
-    line: str, tzinfo: ZoneInfo = PARIS_TZ
-) -> tuple[datetime, datetime | None, str]:
+    line: str, tzinfo: dt.tzinfo = UTC,
+) -> tuple[dt.datetime, dt.datetime | None, str]:
     """Parse ``line`` into start time, optional end time and title.
 
     Datetimes are returned in UTC.
@@ -48,15 +46,15 @@ def parse_event_line(
 
     start_date = _parse_date(parts[0])
     start_time_part = _parse_time(parts[1])
-    start_naive = datetime.combine(start_date.date(), start_time_part.time())
+    start_naive = dt.datetime.combine(start_date.date(), start_time_part.time())
     start = start_naive.replace(tzinfo=tzinfo).astimezone(UTC)
 
     idx = 2
-    end: datetime | None = None
+    end: dt.datetime | None = None
     if len(parts) >= 4 and DATE_RE.fullmatch(parts[2]) and TIME_RE.fullmatch(parts[3]):
         end_date = _parse_date(parts[2])
         end_time_part = _parse_time(parts[3])
-        end_naive = datetime.combine(end_date.date(), end_time_part.time())
+        end_naive = dt.datetime.combine(end_date.date(), end_time_part.time())
         end = end_naive.replace(tzinfo=tzinfo).astimezone(UTC)
         idx = 4
 

--- a/tg_cal_reminder/utils/timezones.py
+++ b/tg_cal_reminder/utils/timezones.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from zoneinfo import ZoneInfo
 
-PARIS = ZoneInfo("Europe/Paris")
 UTC = UTC
 
 
@@ -17,29 +15,19 @@ def to_utc(dt: datetime) -> datetime:
     return dt.astimezone(UTC)
 
 
-def to_paris(dt: datetime) -> datetime:
-    """Convert an aware ``datetime`` to Europe/Paris timezone.
-
-    Raises ``ValueError`` if ``dt`` is naive.
-    """
-    if dt.tzinfo is None:
-        raise ValueError("datetime must be timezone-aware")
-    return dt.astimezone(PARIS)
-
-
 def day_bounds(dt: datetime) -> tuple[datetime, datetime]:
-    """Return start and end of the day for ``dt`` in Europe/Paris."""
-    local = dt.astimezone(PARIS)
-    start = datetime(local.year, local.month, local.day, 0, 0, tzinfo=PARIS)
-    end = datetime(local.year, local.month, local.day, 23, 59, tzinfo=PARIS)
+    """Return start and end of the day for ``dt`` in UTC."""
+    dt_utc = dt.astimezone(UTC)
+    start = datetime(dt_utc.year, dt_utc.month, dt_utc.day, 0, 0, tzinfo=UTC)
+    end = datetime(dt_utc.year, dt_utc.month, dt_utc.day, 23, 59, tzinfo=UTC)
     return start, end
 
 
 def week_bounds(dt: datetime) -> tuple[datetime, datetime]:
-    """Return Monday 00:00 and Sunday 23:59 of the ISO week of ``dt`` in Paris."""
-    local = dt.astimezone(PARIS)
-    monday = local - timedelta(days=local.isoweekday() - 1)
-    start = datetime(monday.year, monday.month, monday.day, 0, 0, tzinfo=PARIS)
+    """Return Monday 00:00 and Sunday 23:59 of the ISO week of ``dt`` in UTC."""
+    dt_utc = dt.astimezone(UTC)
+    monday = dt_utc - timedelta(days=dt_utc.isoweekday() - 1)
+    start = datetime(monday.year, monday.month, monday.day, 0, 0, tzinfo=UTC)
     sunday = start + timedelta(days=6)
-    end = datetime(sunday.year, sunday.month, sunday.day, 23, 59, tzinfo=PARIS)
+    end = datetime(sunday.year, sunday.month, sunday.day, 23, 59, tzinfo=UTC)
     return start, end


### PR DESCRIPTION
## Summary
- update all time handling to UTC
- clean up timezone helpers
- adjust parser and translator for UTC
- clarify scheduler docs and UTC schedules
- update tests for UTC expectations
- update design docs
- add a suggested task about exporting events to iCal

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456041bb54832c93065551e513f7fd