### PR TITLE
Add Telegram command list registration

### DIFF
--- a/design/file_structure.md
+++ b/design/file_structure.md
@@ -10,10 +10,11 @@ calendar_bot/
 │       └── xxxx_initial.py     # Initial schema setup: users and events tables
 ├── tg_cal_reminder/            # Application source code
 │   ├── bot/                    # Bot logic and scheduling
-│   │   ├── __init__.py         
+│   │   ├── __init__.py
 │   │   ├── polling.py          # HTTP polling loop using httpx to fetch Telegram updates
 │   │   ├── handlers.py         # Dispatches incoming messages to command handlers via LLM translation
-│   │   └── scheduler.py        # Defines scheduled tasks for daily, evening, and weekly digests
+│   │   ├── scheduler.py        # Defines scheduled tasks for daily, evening, and weekly digests
+│   │   └── commands.py         # Registers bot command list with Telegram
 │   ├── db/                     # Database layer
 │   │   ├── __init__.py
 │   │   ├── models.py           # SQLAlchemy ORM models: User and Event definitions

--- a/design/specification.md
+++ b/design/specification.md
@@ -33,6 +33,7 @@ The bot:
 | **FR-10** | **Past-date warning rule**: any event whose start is in the past triggers a warning message at creation time but remains valid.                                                                                                                                                              |
 | **FR-11** | **Idempotent polling**: updates processed once must never be re-processed. Store last Telegram update\_id and resume from there after restart.                                                                                                                                               |
 | **FR-12** | **Admin-less**: all functionality is per-user; there is no global admin role.                                                                                                                                                                                                                |
+| **FR-13** | **Command registration**: on startup the bot calls `setMyCommands` so Telegram shows the available commands in the chat UI. |
 
 ---
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,6 +27,13 @@ async def test_main_initializes_components(monkeypatch):
     monkeypatch.setattr(main_mod, "handle_update", dummy_handle)
     monkeypatch.setattr(main_mod, "translate_message", lambda *a, **k: {})
 
+    registered = {}
+
+    async def dummy_register(client):
+        registered["called"] = True
+
+    monkeypatch.setattr(main_mod, "register_commands", dummy_register)
+
     class DummyScheduler:
         def __init__(self):
             self.started = False
@@ -65,5 +72,6 @@ async def test_main_initializes_components(monkeypatch):
     assert poller_instance.run_called
     assert scheduler_instance.started and scheduler_instance.stopped
     assert handle_called.get("called") is True
+    assert registered.get("called") is True
 
     await engine.dispose()

--- a/tg_cal_reminder/bot/commands.py
+++ b/tg_cal_reminder/bot/commands.py
@@ -1,0 +1,16 @@
+import httpx
+
+COMMANDS = [
+    {"command": "start", "description": "Begin conversation"},
+    {"command": "lang", "description": "Change language"},
+    {"command": "add_event", "description": "Add a calendar event"},
+    {"command": "list_events", "description": "List user events"},
+    {"command": "list_all_events", "description": "List events in range"},
+    {"command": "close_event", "description": "Close events"},
+    {"command": "help", "description": "Show help"},
+]
+
+
+async def register_commands(client: httpx.AsyncClient) -> None:
+    """Register bot commands with Telegram."""
+    await client.post("setMyCommands", json={"commands": COMMANDS})

--- a/tg_cal_reminder/main.py
+++ b/tg_cal_reminder/main.py
@@ -8,6 +8,7 @@ from alembic.config import Config
 from dotenv import load_dotenv
 
 from tg_cal_reminder.bot import scheduler
+from tg_cal_reminder.bot.commands import register_commands
 from tg_cal_reminder.bot.polling import Poller
 from tg_cal_reminder.bot.update import handle_update
 from tg_cal_reminder.db.sessions import get_engine, get_sessionmaker
@@ -39,6 +40,8 @@ async def main() -> None:
 
         async def translator(text: str, lang: str) -> dict:
             return await translate_message(llm_client, text, lang)
+
+        await register_commands(tg_client)
 
         poller = Poller(
             token,


### PR DESCRIPTION
## Summary
- define bot commands and register them with Telegram at startup
- test that `main()` registers commands
- document the new file and requirement in design docs

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847596b5dcc832c88be0d2cdf244761