### PR TITLE
Add live LLM tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,6 @@ DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/dbname
 OPENROUTER_API_KEY=your-openrouter-api-key
 # Set to 1 to enable integration tests
 RUN_INTEGRATION_TESTS=
+# Set to 1 to enable live LLM tests
+RUN_LLM_TESTS=
 

--- a/design/file_structure.md
+++ b/design/file_structure.md
@@ -44,3 +44,5 @@ calendar_bot/
     │   └── test_timezones.py   # Tests for timezone helpers in timezones.py
     └── integration/           # End-to-end integration tests
         └── test_end_to_end.py  # Simulates bot flow: user registration, add/list/close events
+llm_tests/                      # Live tests for the OpenRouter LLM
+└── test_translator_live.py     # Verifies translator responses using the real API

--- a/design/running llm tests.md
+++ b/design/running llm tests.md
@@ -1,0 +1,13 @@
+# Running LLM Tests
+
+These optional tests hit the real OpenRouter API to verify the translator's output.
+
+1. Export a valid `OPENROUTER_API_KEY` environment variable.
+2. Enable the suite with `RUN_LLM_TESTS=1`.
+3. Run the tests:
+
+```bash
+pytest llm_tests -q
+```
+
+They are not included in the normal test run defined in `pyproject.toml`.

--- a/llm_tests/test_translator_live.py
+++ b/llm_tests/test_translator_live.py
@@ -1,0 +1,26 @@
+import os
+
+import httpx
+import pytest
+
+from tg_cal_reminder.llm.translator import translate_message
+
+if not (os.environ.get("RUN_LLM_TESTS") and os.environ.get("OPENROUTER_API_KEY")):
+    pytest.skip("LLM tests disabled", allow_module_level=True)
+
+
+@pytest.mark.asyncio
+async def test_help_command():
+    async with httpx.AsyncClient() as client:
+        result = await translate_message(client, "help", "en")
+    assert result.get("command") == "/help"
+
+
+@pytest.mark.asyncio
+async def test_add_event_command():
+    text = "add event 2099-12-31 09:00 New Year Eve"
+    async with httpx.AsyncClient() as client:
+        result = await translate_message(client, text, "en")
+    assert result.get("command") == "/add_event"
+    assert result.get("args")
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,14 +67,14 @@ warn_redundant_casts = true
 warn_return_any = true
 warn_unused_ignores = true
 warn_unused_configs = true
-exclude = "(tests|integration_tests)"
+exclude = "(tests|integration_tests|llm_tests)"
 
 [[tool.mypy.overrides]]
 module = ["apscheduler.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = ["tests.*", "integration_tests.*"]
+module = ["tests.*", "integration_tests.*", "llm_tests.*"]
 disallow_untyped_defs = false
 
 [tool.pytest.ini_options]
@@ -86,4 +86,5 @@ asyncio_default_fixture_loop_scope = "function"
 [tool.hatch.scripts]
 test = "pytest --cov=tg_cal_reminder"
 integration = "pytest integration_tests --cov=tg_cal_reminder"
+llm = "pytest llm_tests --cov=tg_cal_reminder"
 check = ["hatch run test", "hatch run integration"]


### PR DESCRIPTION
## Summary
- create optional llm tests that hit OpenRouter
- document how to run them
- expose RUN_LLM_TESTS in `.env.example`
- update mypy and hatch config for new test suite
- document new folder in file structure design

## Testing
- `ruff check`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684759ff2b94832c9b4645d3cf22b06d