### PR TITLE
Implement edit_event command

### DIFF
--- a/design/list_tg_commands.md
+++ b/design/list_tg_commands.md
@@ -1,15 +1,17 @@
 # List of telegram bot commands
 
-(Anything in ⟨angle brackets⟩ is required; items in \[brackets] are optional.)
+(Anything in ⟨angle brackets⟩ is required; items in [brackets] are optional.)
 
-| Command                       | Parameters & Syntax                                                                               | What it does                                                                                                                                                                              |
-| ----------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **/start**                    | –                                                                                                 | Begins the conversation and prompts the user for their preferred language.                                                                                                                |
-| **/lang ⟨code⟩**              | **code** – two-letter ISO 639-1 language code (e.g., `en`, `fr`, `de`)                            | Changes the language the bot uses to reply.                                                                                                                                               |
-| **/add\_event ⟨event\_line⟩** | **event\_line** – single line in the exact format<br/>`YYYY-MM-DD HH:MM [YYYY-MM-DD HH:MM] Title` | Saves a new calendar entry.<br/>• If the date/time is in the past, the bot saves it but warns the user.<br/>• If a second date/time is supplied, it is treated as the event’s *end* time. |
-| **/list\_events \[username]** | **username** – Telegram @username or numeric ID of the target user (omit for yourself)            | Lists all events for the chosen user, sorted chronologically (open events first, then closed).                                                                                            |
-| **/close\_event ⟨id …⟩**      | One or more **event ID** values, space-separated                                                  | Marks the specified events as *closed* (done/archived).                                                                                                                                   |
-| **/help**                     | –                                                                                                 | Shows a short reminder of every command and its syntax.                                                                                                                                   |
+| Command                       | Parameters & Syntax                                              | What it does                                                                 |
+| ----------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **/start**                    | –                                                                | Begins the conversation and prompts the user for their preferred language. |
+| **/lang ⟨code⟩**              | **code** – two-letter ISO 639-1 language code (e.g., `en`, `fr`) | Changes the language the bot uses to reply.                                 |
+| **/add_event ⟨event_line⟩**   | **event_line** – `YYYY-MM-DD HH:MM [YYYY-MM-DD HH:MM] Title`     | Saves a new calendar entry. Past dates are allowed but trigger a warning.   |
+| **/edit_event ⟨id⟩ ⟨event_line⟩** | **id** – event ID<br>**event_line** – same format as above | Updates an existing event with new details.                                  |
+| **/list_events [username]**   | **username** – Telegram @username or numeric ID                 | Lists all events for the chosen user, open events first.                     |
+| **/list_all_events [from to]**| Optional start and end date/time                                | Lists events in the specified range.                                        |
+| **/close_event ⟨id …⟩**       | One or more **event ID** values                                  | Marks the specified events as *closed*.                                      |
+| **/help**                     | –                                                                | Shows a short reminder of every command and its syntax.                      |
 
 ---
 

--- a/design/program_description_text.md
+++ b/design/program_description_text.md
@@ -14,10 +14,11 @@ Telegram bot using **httpx** with the Telegram HTTP Bot API, a **PostgreSQL** da
 ## Features
 1. Save events to a user’s calendar.
 2. Show all events, sorted by time, for the current or any specified user.
-3. Close events by their IDs.
-4. Every evening, list events planned for the next day.
-5. Every morning, list events planned for the same day.
-6. Every Monday, list events planned for the week.
+3. Edit existing events by ID.
+4. Close events by their IDs.
+5. Every evening, list events planned for the next day.
+6. Every morning, list events planned for the same day.
+7. Every Monday, list events planned for the week.
 
 The bot polls Telegram for messages—no webhooks are used.
 

--- a/design/specification.md
+++ b/design/specification.md
@@ -25,16 +25,16 @@ The bot:
 | **FR-2**  | **Language onboarding**: as soon as the secret is accepted, ask for user’s preferred language (`/lang <code>` behind the scenes) and store it. Replies must thereafter be localised via `i18n/messages.py`.                                                                                  |
 | **FR-3**  | **Rigid command set**: only the commands in § 3 are accepted. All free-text is routed through the LLM translator which must emit one of those commands or an error.                                                                                                                          |
 | **FR-4**  | **/add\_event**: accept exactly `YYYY-MM-DD HH:MM [YYYY-MM-DD HH:MM] Title` (no semicolons).<br/>• If end-time is omitted the event is open-ended.<br/>• If start < now(), save anyway but warn the user.<br/>• Both datetimes are stored in UTC and displayed in UTC. |
-| **FR-5**  | **/list\_events \[username]**: list events for the target (default = caller) in chronological order: (1) open events, (2) closed events, each with ID, start, end (if any) and title.                                                                                                        |
-| **FR-6**  | **/close\_event \<id …>**: mark one or many events as closed; ignore unknown IDs; report which ones changed.                                                                                                                                                                                 |
-| **FR-7**  | **/lang <code>** at any time updates the language and persists it.                                                                                                                                                                                                                           |
-| **FR-8**  | **/help** prints a concise multilingual cheat-sheet of every command and the event format.                                                                                                                                                                                                   |
-| **FR-9**  | **Automatic digests** (sent only to the owner of the events):<br/>• every evening (19:00) – events for the next day<br/>• every morning (08:00) – events for today<br/>• every Monday 08:00 – events for Mon-Sun of the current week                                                         |
-| **FR-10** | **Past-date warning rule**: any event whose start is in the past triggers a warning message at creation time but remains valid.                                                                                                                                                              |
-| **FR-11** | **Idempotent polling**: updates processed once must never be re-processed. Store last Telegram update\_id and resume from there after restart.                                                                                                                                               |
-| **FR-12** | **Admin-less**: all functionality is per-user; there is no global admin role.                                                                                                                                                                                                                |
-| **FR-13** | **Command registration**: on startup the bot calls `setMyCommands` so Telegram shows the available commands in the chat UI. |
-
+| **FR-5**  | **/edit_event <id> <event_line>**: update an existing event with new date/time and title. Same rules as `/add_event` for past dates and formatting. |
+| **FR-6**  | **/list_events [username]**: list events for the target (default = caller) in chronological order: (1) open events, (2) closed events, each with ID, start, end (if any) and title. |
+| **FR-7**  | **/close_event <id …>**: mark one or many events as closed; ignore unknown IDs; report which ones changed. |
+| **FR-8**  | **/lang <code>** at any time updates the language and persists it. |
+| **FR-9**  | **/help** prints a concise multilingual cheat-sheet of every command and the event format. |
+| **FR-10** | **Automatic digests** (sent only to the owner of the events):<br/>• every evening (19:00) – events for the next day<br/>• every morning (08:00) – events for today<br/>• every Monday 08:00 – events for Mon-Sun of the current week                                                         |
+| **FR-11** | **Past-date warning rule**: any event whose start is in the past triggers a warning message at creation time but remains valid. |
+| **FR-12** | **Idempotent polling**: updates processed once must never be re-processed. Store last Telegram update_id and resume from there after restart. |
+| **FR-13** | **Admin-less**: all functionality is per-user; there is no global admin role. |
+| **FR-14** | **Command registration**: on startup the bot calls `setMyCommands` so Telegram shows the available commands in the chat UI. |
 ---
 
 ## 3. User-visible commands (strict grammar)
@@ -43,7 +43,9 @@ The bot:
 /start
 /lang <code>                 # ISO-639-1, two letters
 /add_event <event_line>      # rigid syntax above
+/edit_event <id> <event_line>
 /list_events [username]
+/list_all_events [from to]
 /close_event <id …>
 /help
 ```

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -117,3 +117,18 @@ async def test_close_events_empty_and_cross_user(async_session: AsyncSession):
     refreshed = await crud.list_events(async_session, user2.id)
     assert refreshed[0].is_closed is False
 
+
+@pytest.mark.asyncio
+async def test_update_event(async_session: AsyncSession):
+    user = await crud.create_user(async_session, telegram_id=30)
+    now = datetime.datetime.now(datetime.UTC)
+    event = await crud.create_event(async_session, user.id, now, title="orig")
+
+    new_start = now + datetime.timedelta(hours=1)
+    updated = await crud.update_event(
+        async_session, user.id, event.id, new_start, "updated", None
+    )
+    assert updated is not None
+    assert updated.title == "updated"
+    assert updated.start_time == new_start.replace(tzinfo=None)
+

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -52,3 +52,8 @@ async def test_translate_message_http_error(monkeypatch):
     async with httpx.AsyncClient(transport=transport) as client:
         with pytest.raises(RuntimeError):
             await translate_message(client, "hello", "en")
+
+
+def test_system_prompt_contains_edit_event() -> None:
+    """Ensure new command is documented in the system prompt."""
+    assert "/edit_event" in SYSTEM_PROMPT

--- a/tg_cal_reminder/bot/commands.py
+++ b/tg_cal_reminder/bot/commands.py
@@ -4,6 +4,7 @@ COMMANDS = [
     {"command": "start", "description": "Begin conversation"},
     {"command": "lang", "description": "Change language"},
     {"command": "add_event", "description": "Add a calendar event"},
+    {"command": "edit_event", "description": "Edit an event"},
     {"command": "list_events", "description": "List user events"},
     {"command": "list_all_events", "description": "List events in range"},
     {"command": "close_event", "description": "Close events"},

--- a/tg_cal_reminder/bot/handlers.py
+++ b/tg_cal_reminder/bot/handlers.py
@@ -71,6 +71,24 @@ async def handle_add_event(ctx: CommandContext, args: str) -> str:
     return f"Event {event.id} added{warning}: {time_str} {title} | id={event.id}"
 
 
+async def handle_edit_event(ctx: CommandContext, args: str) -> str:
+    parts = args.split(maxsplit=1)
+    if len(parts) != 2 or not parts[0].isdigit():
+        raise HandlerError("Invalid edit format")
+    event_id = int(parts[0])
+    start, end, title = await parse_event_line(parts[1])
+    event = await crud.update_event(
+        ctx.session, ctx.user.id, event_id, start, title, end
+    )
+    if event is None:
+        raise HandlerError("Event not found")
+    warning = ""
+    if start < datetime.now(UTC):
+        warning = " (past event)"
+    time_str = start.astimezone(UTC).strftime("%Y-%m-%d %H:%M")
+    return f"Event {event.id} updated{warning}: {time_str} {title} | id={event.id}"
+
+
 def _parse_range(args: str) -> tuple[datetime | None, datetime | None]:
     parts = args.split()
     if not parts:
@@ -157,6 +175,11 @@ async def handle_help(ctx: CommandContext, args: str) -> str:
             Optional: end date/time in brackets
             Example: /add_event 2024-05-17 14:30 Team meeting
             Example: /add_event 2024-05-17 14:30 2024-05-17 15:30 Team meeting
+        /edit_event <id> <YYYY-MM-DD HH:mm [YYYY-MM-DD HH:mm] title>
+            Required: event id and new start date/time
+            Optional: end date/time in brackets
+            Example: /edit_event 1 2024-05-17 14:30 Updated meeting
+            Example: /edit_event 1 2024-05-17 14:30 2024-05-17 15:30 Updated meeting
         /list_events [username]
         /list_all_events [<YYYY-MM-DD HH:mm> [YYYY-MM-DD HH:mm]]
             Optional: start date/time
@@ -176,6 +199,7 @@ _HANDLERS: dict[str, CommandHandler] = {
     "/start": handle_start,
     "/lang": handle_lang,
     "/add_event": handle_add_event,
+    "/edit_event": handle_edit_event,
     "/list_events": handle_list_events,
     "/list_all_events": handle_list_all_events,
     "/close_event": handle_close_event,

--- a/tg_cal_reminder/db/crud.py
+++ b/tg_cal_reminder/db/crud.py
@@ -138,3 +138,24 @@ async def list_events_between(
     stmt = stmt.order_by(Event.is_closed, Event.start_time)
     result = await session.execute(stmt)
     return list(result.scalars())
+
+
+async def update_event(
+    session: AsyncSession,
+    user_id: int,
+    event_id: int,
+    start_time: datetime,
+    title: str,
+    end_time: datetime | None = None,
+) -> Event | None:
+    """Update an event belonging to ``user_id`` and return it or ``None``."""
+    event = await session.get(Event, event_id)
+    if event is None or event.user_id != user_id:
+        return None
+
+    event.start_time = start_time
+    event.end_time = end_time
+    event.title = title
+    await session.commit()
+    await session.refresh(event)
+    return event

--- a/tg_cal_reminder/i18n/messages.py
+++ b/tg_cal_reminder/i18n/messages.py
@@ -11,6 +11,7 @@ MESSAGES: dict[str, dict[str, str]] = {
         "language_set": "Language changed to {language}.",
         "help": (
             "/add_event <event_line> – add event\n"
+            "/edit_event <id event_line> – edit event\n"
             "/list_events [username] – list events\n"
             "/list_all_events [from to] – list events in range\n"
             "/close_event <id …> – close events\n"
@@ -24,6 +25,7 @@ MESSAGES: dict[str, dict[str, str]] = {
         "language_set": "La langue a été définie sur {language}.",
         "help": (
             "/add_event <ligne> – ajouter un événement\n"
+            "/edit_event <id ligne> – modifier un événement\n"
             "/list_events [utilisateur] – lister les événements\n"
             "/list_all_events [from to] – lister la plage\n"
             "/close_event <id …> – clôturer des événements\n"
@@ -37,6 +39,7 @@ MESSAGES: dict[str, dict[str, str]] = {
         "language_set": "Язык изменен на {language}.",
         "help": (
             "/add_event <событие> – добавить событие\n"
+            "/edit_event <id событие> – изменить событие\n"
             "/list_events [пользователь] – список событий\n"
             "/list_all_events [from to] – события в диапазоне\n"
             "/close_event <id …> – закрыть события\n"

--- a/tg_cal_reminder/llm/model.py
+++ b/tg_cal_reminder/llm/model.py
@@ -9,6 +9,7 @@ class TranslatorResponse(BaseModel):
             "/start",
             "/lang",
             "/add_event",
+            "/edit_event",
             "/list_events",
             "/list_all_events",
             "/close_event",
@@ -28,6 +29,11 @@ class TranslatorResponse(BaseModel):
             Optional: end date/time in brackets
             Example: /add_event 2024-05-17 14:30 Team meeting
             Example: /add_event 2024-05-17 14:30 2024-05-17 15:30 Team meeting
+        /edit_event <id> <YYYY-MM-DD HH:mm [YYYY-MM-DD HH:mm] title>
+            Required: event id and new start date/time
+            Optional: end date/time in brackets
+            Example: /edit_event 1 2024-05-17 14:30 Updated meeting
+            Example: /edit_event 1 2024-05-17 14:30 2024-05-17 15:30 Updated meeting
         /list_events [username]
         /list_all_events [<YYYY-MM-DD HH:mm> [YYYY-MM-DD HH:mm]]
             Optional: start date/time

--- a/tg_cal_reminder/llm/translator.py
+++ b/tg_cal_reminder/llm/translator.py
@@ -18,8 +18,8 @@ SYSTEM_PROMPT = textwrap.dedent(
     You are a translation layer for a Telegram bot.
     Current time: {get_current_time_utc()}.
     Translate the user message into one of the supported commands:
-    /start, /lang <code>, /add_event <event_line>, /list_events [username],
-    /list_all_events [from to], /close_event <id …>, /help.
+    /start, /lang <code>, /add_event <event_line>, /edit_event <id> <event_line>,
+    /list_events [username], /list_all_events [from to], /close_event <id …>, /help.
     Return a JSON object correspoding to this Pedantic model:
     ```python
     class TranslatorResponse(BaseModel):
@@ -28,6 +28,7 @@ SYSTEM_PROMPT = textwrap.dedent(
                 "/start",
                 "/lang",
                 "/add_event",
+                "/edit_event",
                 "/list_events",
                 "/list_all_events",
                 "/close_event",
@@ -50,6 +51,11 @@ SYSTEM_PROMPT = textwrap.dedent(
             Optional: end date/time in brackets
             Example: /add_event 2024-05-17 14:30 Team meeting
             Example: /add_event 2024-05-17 14:30 2024-05-17 15:30 Team meeting
+        /edit_event <id> <YYYY-MM-DD HH:mm [YYYY-MM-DD HH:mm] title>
+            Required: event id and new start date/time
+            Optional: end date/time in brackets
+            Example: /edit_event 1 2024-05-17 14:30 Updated meeting
+            Example: /edit_event 1 2024-05-17 14:30 2024-05-17 15:30 Updated meeting
         /list_events [username]
         /list_all_events [<YYYY-MM-DD HH:mm> [YYYY-MM-DD HH:mm]]
             Optional: start date/time


### PR DESCRIPTION
## Summary
- add `/edit_event` command support and help text
- enable editing events in CRUD layer and add tests
- document `/edit_event` in messages, translator and design docs

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847cfc18fd0832cb42ba9565e2a0c28