### PR TITLE
Add /edit_event command

### DIFF
--- a/design/list_tg_commands.md
+++ b/design/list_tg_commands.md
@@ -5,13 +5,14 @@
 | Command                       | Parameters & Syntax                                                                               | What it does                                                                                                                                                                              |
 | ----------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **/start**                    | –                                                                                                 | Begins the conversation and prompts the user for their preferred language.                                                                                                                |
-| **/lang ⟨code⟩**              | **code** – two-letter ISO 639-1 language code (e.g., `en`, `fr`, `de`)                            | Changes the language the bot uses to reply.                                                                                                                                               |
+| **/lang ⟨code⟩**              | **code** – two-letter ISO 639-1 language code (e.g., `en`, `fr`, `de`)                            | Changes the language the bot uses to reply.
 | **/timezone ⟨name⟩**          | **name** – IANA timezone name (e.g., `Europe/Moscow`, `Europe/Paris`, `America/New_York`) | Sets your preferred timezone.
-|
-| **/add\_event ⟨event\_line⟩** | **event\_line** – single line in the exact format<br/>`YYYY-MM-DD HH:MM [YYYY-MM-DD HH:MM] Title` | Saves a new calendar entry.<br/>• If the date/time is in the past, the bot saves it but warns the user.<br/>• If a second date/time is supplied, it is treated as the event’s *end* time. |
-| **/list\_events \[username]** | **username** – Telegram @username or numeric ID of the target user (omit for yourself)            | Lists all events for the chosen user, sorted chronologically (open events first, then closed).                                                                                            |
-| **/close\_event ⟨id …⟩**      | One or more **event ID** values, space-separated                                                  | Marks the specified events as *closed* (done/archived).                                                                                                                                   |
-| **/help**                     | –                                                                                                 | Shows a short reminder of every command and its syntax.                                                                                                                                   |
+| **/add_event ⟨event_line⟩** | **event_line** – single line in the exact format<br/>`YYYY-MM-DD HH:MM [YYYY-MM-DD HH:MM] Title` | Saves a new calendar entry.<br/>• If the date/time is in the past, the bot saves it but warns the user.<br/>• If a second date/time is supplied, it is treated as the event’s *end* time.
+| **/edit_event ⟨id event_line⟩** | **id** – event ID to update<br/>**event_line** – same format as `/add_event` | Updates the specified event with new data.
+| **/list_events [username]** | **username** – Telegram @username or numeric ID of the target user (omit for yourself)            | Lists all events for the chosen user, sorted chronologically (open events first, then closed).
+| **/list_all_events [from to]** | Optional **from** and **to** datetimes in the same format as events | Lists events within the provided range.
+| **/close_event ⟨id …⟩**      | One or more **event ID** values, space-separated                                                  | Marks the specified events as *closed* (done/archived).
+| **/help**                     | –                                                    | Shows a short reminder of every command and its syntax.
 
 ---
 

--- a/design/specification.md
+++ b/design/specification.md
@@ -42,7 +42,9 @@ The bot:
 /start
 /lang <code>                 # ISO-639-1, two letters
 /add_event <event_line>      # rigid syntax above
+/edit_event <id event_line>
 /list_events [username]
+/list_all_events [from to]
 /timezone <name>
 /close_event <id …>
 /help

--- a/tg_cal_reminder/bot/commands.py
+++ b/tg_cal_reminder/bot/commands.py
@@ -4,6 +4,7 @@ COMMANDS = [
     {"command": "start", "description": "Begin conversation"},
     {"command": "lang", "description": "Change language"},
     {"command": "add_event", "description": "Add a calendar event"},
+    {"command": "edit_event", "description": "Edit an event"},
     {"command": "list_events", "description": "List user events"},
     {"command": "list_all_events", "description": "List events in range"},
     {"command": "close_event", "description": "Close events"},

--- a/tg_cal_reminder/db/crud.py
+++ b/tg_cal_reminder/db/crud.py
@@ -112,6 +112,29 @@ async def close_events(
     return [row[0] for row in result.fetchall()]
 
 
+async def update_event(
+    session: AsyncSession,
+    user_id: int,
+    event_id: int,
+    start_time: datetime,
+    title: str,
+    end_time: datetime | None = None,
+) -> bool:
+    """Update an event owned by ``user_id``.
+
+    Returns ``True`` if an event was updated, ``False`` otherwise.
+    """
+    stmt = (
+        update(Event)
+        .where(and_(Event.user_id == user_id, Event.id == event_id))
+        .values(start_time=start_time, end_time=end_time, title=title)
+        .returning(Event.id)
+    )
+    result = await session.execute(stmt)
+    await session.commit()
+    return result.scalar_one_or_none() is not None
+
+
 async def get_events_between(
     session: AsyncSession,
     user_id: int,

--- a/tg_cal_reminder/i18n/messages.py
+++ b/tg_cal_reminder/i18n/messages.py
@@ -11,6 +11,7 @@ MESSAGES: dict[str, dict[str, str]] = {
         "language_set": "Language changed to {language}.",
         "help": (
             "/add_event <event_line> – add event\n"
+            "/edit_event <id event_line> – edit event\n"
             "/list_events [username] – list events\n"
             "/list_all_events [from to] – list events in range\n"
             "/close_event <id …> – close events\n"
@@ -25,6 +26,7 @@ MESSAGES: dict[str, dict[str, str]] = {
         "language_set": "La langue a été définie sur {language}.",
         "help": (
             "/add_event <ligne> – ajouter un événement\n"
+            "/edit_event <id ligne> – modifier un événement\n"
             "/list_events [utilisateur] – lister les événements\n"
             "/list_all_events [from to] – lister la plage\n"
             "/close_event <id …> – clôturer des événements\n"
@@ -39,6 +41,7 @@ MESSAGES: dict[str, dict[str, str]] = {
         "language_set": "Язык изменен на {language}.",
         "help": (
             "/add_event <событие> – добавить событие\n"
+            "/edit_event <id событие> – изменить событие\n"
             "/list_events [пользователь] – список событий\n"
             "/list_all_events [from to] – события в диапазоне\n"
             "/close_event <id …> – закрыть события\n"

--- a/tg_cal_reminder/llm/translator.py
+++ b/tg_cal_reminder/llm/translator.py
@@ -21,8 +21,9 @@ SYSTEM_PROMPT = textwrap.dedent(
     You are a translation layer for a Telegram bot.
     Current time: {get_current_time_utc()}.
     Translate the user message into one of the supported commands:
-    /start, /lang <code>, /add_event <event_line>, /list_events [username],
-    /list_all_events [from to], /close_event <id …>, /timezone <name>, /help.
+    /start, /lang <code>, /add_event <event_line>, /edit_event <id event_line>,
+    /list_events [username], /list_all_events [from to], /close_event <id …>,
+    /timezone <name>, /help.
     Return a JSON object correspoding to this Pedantic model:
     ```python
     class TranslatorResponse(BaseModel):
@@ -31,6 +32,7 @@ SYSTEM_PROMPT = textwrap.dedent(
                 "/start",
                 "/lang",
                 "/add_event",
+                "/edit_event",
                 "/list_events",
                 "/list_all_events",
                 "/close_event",
@@ -54,6 +56,9 @@ SYSTEM_PROMPT = textwrap.dedent(
             Optional: end date/time in brackets
             Example: /add_event 2024-05-17 14:30 Team meeting
             Example: /add_event 2024-05-17 14:30 2024-05-17 15:30 Team meeting
+        /edit_event <id> <YYYY-MM-DD HH:mm [YYYY-MM-DD HH:mm] title>
+            Example: /edit_event 5 2024-05-17 14:30 Updated meeting
+            Example: /edit_event 5 2024-05-17 14:30 2024-05-17 15:00 Updated meeting
         /list_events [username]
         /list_all_events [<YYYY-MM-DD HH:mm> [YYYY-MM-DD HH:mm]]
             Optional: start date/time


### PR DESCRIPTION
## Summary
- implement `/edit_event` handler and add new detailed help information
- support editing events via DB `update_event`
- extend translator prompt and command registration
- update i18n help text
- document new command in design docs
- add unit tests for update and handler

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d537c450832cbe2a7c6f11c880ca