### PR TITLE
Reset root log level post-migration

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import pytest
@@ -68,6 +69,8 @@ async def test_main_initializes_components(monkeypatch):
     monkeypatch.setattr(main_mod, "Poller", poller_factory)
 
     await main_mod.main()
+
+    assert logging.getLogger().level == logging.INFO
 
     assert poller_instance.run_called
     assert scheduler_instance.started and scheduler_instance.stopped

--- a/tg_cal_reminder/main.py
+++ b/tg_cal_reminder/main.py
@@ -32,6 +32,9 @@ async def main() -> None:
     # Alembic's upgrade command uses ``asyncio.run`` internally which would
     # block the running event loop, so run it in a separate thread instead.
     await asyncio.to_thread(command.upgrade, Config("alembic.ini"), "head")
+    level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
+    root_level = getattr(logging, level_name, logging.INFO)
+    logging.getLogger().setLevel(root_level)
 
     async with (
         httpx.AsyncClient(base_url=f"https://api.telegram.org/bot{token}/") as tg_client,


### PR DESCRIPTION
## Summary
- restore root logger level after running alembic migrations
- ensure logger level stays `INFO` in tests

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685146c8ca80832caee67659fbdd527e