### PR TITLE
Use user timezone in system prompt

### DIFF
--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -4,7 +4,11 @@ import httpx
 import pytest
 
 from tg_cal_reminder.llm import translator
-from tg_cal_reminder.llm.translator import OPENROUTER_URL, SYSTEM_PROMPT, translate_message
+from tg_cal_reminder.llm.translator import (
+    OPENROUTER_URL,
+    build_system_prompt,
+    translate_message,
+)
 
 
 @pytest.mark.asyncio
@@ -12,18 +16,20 @@ async def test_translate_message_success(monkeypatch):
     """Translator returns parsed JSON from LLM on success."""
     expected = {"command": "/help", "args": []}
 
+    monkeypatch.setattr(translator, "get_current_time", lambda tz: "2024-01-01 00:00:00 UTC")
+
     async def handler(request: httpx.Request) -> httpx.Response:
         assert request.url == httpx.URL(OPENROUTER_URL)
         payload = json.loads(request.content.decode())
         # Ensure system prompt and user message are included
-        assert payload["messages"][0]["content"] == SYSTEM_PROMPT
+        assert payload["messages"][0]["content"] == build_system_prompt("UTC")
         assert payload["messages"][1]["content"] == "en>>> hello"
         data = {"choices": [{"message": {"content": json.dumps(expected)}}]}
         return httpx.Response(200, json=data)
 
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport, base_url="https://openrouter.ai") as client:
-        result = await translate_message(client, "hello", "en")
+        result = await translate_message(client, "hello", "en", "UTC")
 
     assert result == expected
 

--- a/tg_cal_reminder/bot/handlers.py
+++ b/tg_cal_reminder/bot/handlers.py
@@ -231,7 +231,7 @@ async def dispatch(
     user: User,
     text: str,
     language_code: str,
-    translator: Callable[[str, str], Awaitable[dict]] | None = None,
+    translator: Callable[[str, str, str], Awaitable[dict]] | None = None,
 ) -> str:
     ctx = CommandContext(session=session, user=user)
 
@@ -248,7 +248,7 @@ async def dispatch(
     else:
         if translator is None:
             raise HandlerError("No translator provided for free text")
-        result = await translator(text, language_code)
+        result = await translator(text, language_code, user.timezone)
         if "error" in result:
             raise HandlerError(result["error"])
         command = result.get("command", "")

--- a/tg_cal_reminder/bot/update.py
+++ b/tg_cal_reminder/bot/update.py
@@ -14,7 +14,7 @@ async def handle_update(
     update: dict,
     tg_client: httpx.AsyncClient,
     session_factory: async_sessionmaker[AsyncSession],
-    translator: Callable[[str, str], Awaitable[dict[str, Any]]],
+    translator: Callable[[str, str, str], Awaitable[dict[str, Any]]],
 ) -> None:
     """Process a single Telegram update."""
     message = update.get("message")
@@ -34,7 +34,9 @@ async def handle_update(
         if user is None:
             user = await crud.create_user(session, telegram_id, username=username)
         try:
-            reply = await handlers.dispatch(session, user, text, user.language, translator)
+            reply = await handlers.dispatch(
+                session, user, text, user.language, translator
+            )
         except handlers.HandlerError as err:
             reply = str(err)
 

--- a/tg_cal_reminder/main.py
+++ b/tg_cal_reminder/main.py
@@ -41,8 +41,8 @@ async def main() -> None:
         httpx.AsyncClient() as llm_client,
     ):
 
-        async def translator(text: str, lang: str) -> dict:
-            return await translate_message(llm_client, text, lang)
+        async def translator(text: str, lang: str, tz: str) -> dict:
+            return await translate_message(llm_client, text, lang, tz)
 
         await register_commands(tg_client)
 


### PR DESCRIPTION
## Summary
- allow translator to generate the system prompt using the user's timezone
- update handlers, update routine and main to pass timezone through to the translator
- adjust translator tests for dynamic time handling

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851ac94a7ac832c828fbd8c27407a11