### PR TITLE
Fix handling of translator errors

### DIFF
--- a/tg_cal_reminder/bot/handlers.py
+++ b/tg_cal_reminder/bot/handlers.py
@@ -249,8 +249,9 @@ async def dispatch(
         if translator is None:
             raise HandlerError("No translator provided for free text")
         result = await translator(text, language_code, user.timezone)
-        if "error" in result:
-            raise HandlerError(result["error"])
+        error = result.get("error")
+        if error:
+            raise HandlerError(error)
         command = result.get("command", "")
         raw_args = result.get("args")
         args = " ".join(raw_args) if isinstance(raw_args, list) else raw_args or ""


### PR DESCRIPTION
## Summary
- fix translator result handling in `dispatch`

## Testing
- `pytest -q`
- `mypy tg_cal_reminder`
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_6851c8e6be8c832cba8570d362b65d12