### PR TITLE
List_events includes today's past events

### DIFF
--- a/design/list_tg_commands.md
+++ b/design/list_tg_commands.md
@@ -9,7 +9,7 @@
 | **/timezone ⟨name⟩**          | **name** – IANA timezone name (e.g., `Europe/Moscow`, `Europe/Paris`, `America/New_York`) | Sets your preferred timezone.
 | **/add_event ⟨event_line⟩** | **event_line** – single line in the exact format<br/>`YYYY-MM-DD HH:MM [YYYY-MM-DD HH:MM] Title` | Saves a new calendar entry.<br/>• If the date/time is in the past, the bot saves it but warns the user.<br/>• If a second date/time is supplied, it is treated as the event’s *end* time.
 | **/edit_event ⟨id event_line⟩** | **id** – event ID to update<br/>**event_line** – same format as `/add_event` | Updates the specified event with new data.
-| **/list_events [username]** | **username** – Telegram @username or numeric ID of the target user (omit for yourself)            | Lists all events for the chosen user, sorted chronologically (open events first, then closed).
+| **/list_events [username]** | **username** – Telegram @username or numeric ID of the target user (omit for yourself)            | Lists events for the chosen user starting from the beginning of their current day, sorted chronologically (open events first, then closed).
 | **/list_all_events [from to]** | Optional **from** and **to** datetimes in the same format as events | Lists events within the provided range.
 | **/close_event ⟨id …⟩**      | One or more **event ID** values, space-separated                                                  | Marks the specified events as *closed* (done/archived).
 | **/help**                     | –                                                    | Shows a short reminder of every command and its syntax.

--- a/design/specification.md
+++ b/design/specification.md
@@ -24,7 +24,7 @@ The bot:
 * **Language onboarding**: as soon as the secret is accepted, ask for user’s preferred language (`/lang <code>` behind the scenes) and store it. Replies must thereafter be localised via `i18n/messages.py`.
 * **Rigid command set**: only the commands in § 3 are accepted. All free-text is routed through the LLM translator which must emit one of those commands or an error.
 * **/add_event**: accept exactly `YYYY-MM-DD HH:MM [YYYY-MM-DD HH:MM] Title` (no semicolons).<br/>• If end-time is omitted the event is open-ended.<br/>• If start < now(), save anyway but warn the user.<br/>• Both datetimes are stored in UTC and displayed in UTC.
-* **/list_events [username]**: list events for the target (default = caller) in chronological order: (1) open events, (2) closed events, each with ID, start, end (if any) and title.
+* **/list_events [username]**: list events for the target (default = caller) starting from the beginning of their current day in their timezone, in chronological order: (1) open events, (2) closed events, each with ID, start, end (if any) and title.
 * **/close_event <id …>**: mark one or many events as closed; ignore unknown IDs; report which ones changed.
 * **/lang <code>** at any time updates the language and persists it.
 * **/help** prints a concise multilingual cheat-sheet of every command and the event format.


### PR DESCRIPTION
## Summary
- include events from the start of the user's day in `/list_events`
- update design docs for the new behaviour
- adjust tests for midnight-based filtering

## Testing
- `ruff check`
- `mypy tg_cal_reminder`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851d2b38eb4832c97fc6fbf62a27a29