### PR TITLE
Fix LLM logging setup

### DIFF
--- a/tg_cal_reminder/main.py
+++ b/tg_cal_reminder/main.py
@@ -12,10 +12,12 @@ from tg_cal_reminder.bot.commands import register_commands
 from tg_cal_reminder.bot.polling import Poller
 from tg_cal_reminder.bot.update import handle_update
 from tg_cal_reminder.db.sessions import get_engine, get_sessionmaker
+from tg_cal_reminder.llm import translator
 from tg_cal_reminder.llm.translator import translate_message
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+translator.logger.setLevel(logging.INFO)
 
 
 async def main() -> None:


### PR DESCRIPTION
## Summary
- adjust root logger to display translator output

## Testing
- `ruff check`
- `mypy tg_cal_reminder --ignore-missing-imports` *(fails: Returning Any from function)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6851e9be465c832c98abe7c44688bb45